### PR TITLE
Fix uninitialized variable in thetaToModel

### DIFF
--- a/modeler/@Modeler/thetaToModel.m
+++ b/modeler/@Modeler/thetaToModel.m
@@ -12,6 +12,11 @@ M.blur_sigma=0.5;
 
 count=1;
 
+% initialize globalShift in case list_sid does not include the
+% first stroke. This avoids using an undefined variable when
+% updating positions of other strokes.
+globalShift=[0,0];
+
 
 M.parameters.ink_ncon=theta(count);
 count=count+1;


### PR DESCRIPTION
## Summary
- prevent `globalShift` from being undefined in `thetaToModel`

## Testing
- `git show -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683fec09bcb88332afed4a28fcf123df